### PR TITLE
Add skeleton directories with placeholder docs

### DIFF
--- a/control/motion/README.md
+++ b/control/motion/README.md
@@ -1,0 +1,1 @@
+Placeholder for robot motion control.

--- a/control/turret/README.md
+++ b/control/turret/README.md
@@ -1,0 +1,1 @@
+Placeholder for turret control module.

--- a/hardware/config/README.md
+++ b/hardware/config/README.md
@@ -1,0 +1,1 @@
+Placeholder for hardware configuration.

--- a/interface/api/README.md
+++ b/interface/api/README.md
@@ -1,0 +1,1 @@
+Placeholder for API server.

--- a/interface/websocket/README.md
+++ b/interface/websocket/README.md
@@ -1,0 +1,1 @@
+Placeholder for WebSocket interface.

--- a/ios-app/ThinkTankApp/README.md
+++ b/ios-app/ThinkTankApp/README.md
@@ -1,0 +1,1 @@
+Placeholder for the ThinkTank iOS app project.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,1 @@
+Placeholder for project tests.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,1 @@
+Placeholder for shared utilities.

--- a/vision/model/README.md
+++ b/vision/model/README.md
@@ -1,0 +1,1 @@
+Placeholder for vision model code.

--- a/vision/streaming/README.md
+++ b/vision/streaming/README.md
@@ -1,0 +1,1 @@
+Placeholder for vision streaming module.


### PR DESCRIPTION
## Summary
- scaffold directories for the iOS app, vision modules, control, hardware, interface, utilities, and tests
- add simple README placeholders for each

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543b2def50832db63dd44300fc300a